### PR TITLE
Raise an exception when no particles are found

### DIFF
--- a/pyread_eagle/_pyread_eagle.py
+++ b/pyread_eagle/_pyread_eagle.py
@@ -397,7 +397,12 @@ class EagleSnapshot(object):
                     sub = sub[:int(np.floor(retval.shape[0]
                                             * self.sampling_rate))]
                     all_retval.append(retval[sub])
-        return np.concatenate(all_retval)
+                    
+        if len(all_retval) == 0:
+            raise ValueError('No particles found')
+            return
+        else:
+            return np.concatenate(all_retval)
 
     @check_open
     def datasets(self, itype):


### PR DESCRIPTION
Hi Kyle,

Thanks for your brilliant work porting read_eagle over to pure python! At LJMU, getting new students set up working with EAGLE has always been a total nightmare on our systems because of the specific HDF5 installations needed etc. This version will simplify things enormously, so thanks!

I'm shifting to using your version in my scripts, and have come across an issue where the code will fail if you select a region that happens to have no particles in it, and then try to load something. I think the original read_eagle caught this error differently, but here, np.concatenate(all_retval) will complain that there is nothing to concatenate.

This might seem like a non-issue, because why would you try to load something that doesn't exist? I come across the issue when I load in the stellar contents of FoF haloes above a certain mass in a loop, and for many low-mass haloes there are no star particles. Just thought this was worth throwing an exception for, I've implemented this in my fork and thought you might want to merge this into the main repo.

Thanks again for creating this great tool! I'll let you know if I find any more bugs.

Cheers,

Jon Davies