### PR TITLE
Faster _get_dataset_list implementation

### DIFF
--- a/pyread_eagle/_pyread_eagle.py
+++ b/pyread_eagle/_pyread_eagle.py
@@ -48,28 +48,15 @@ _roty_table = np.array([0, 1, 1, 2, 2, 3, 3, 0])
 
 _sense_table = np.array([-1, -1, -1, +1, +1, -1, -1, -1])
 
-
 def _get_dataset_list(grp, prefix=""):
-    all_objs = list()
-    if prefix:
-        grp[prefix].visit(all_objs.append)
-    else:
-        grp.visit(all_objs.append)
-    all_dsets = ['/' + obj
-                 for obj in all_objs
-                 if isinstance(grp[obj], h5py.Dataset)]
-    return all_dsets
-
-
-def _get_dataset_list_new(grp, prefix=""):
     all_dsets = []
     if prefix:
-        all_dsets = _get_dataset_list_new(grp[prefix])
+        all_dsets = _get_dataset_list(grp[prefix])
         all_dsets = ['/' + prefix + dset_name for dset_name in all_dsets]
     else:
         for key in grp.keys():
             if isinstance(grp[key],h5py._hl.group.Group):
-                all_dsets.extend(_get_dataset_list_new(grp, key)) 
+                all_dsets.extend(_get_dataset_list(grp, key)) 
             else:
                 all_dsets.append('/' + key)
     return all_dsets

--- a/pyread_eagle/_pyread_eagle.py
+++ b/pyread_eagle/_pyread_eagle.py
@@ -61,6 +61,19 @@ def _get_dataset_list(grp, prefix=""):
     return all_dsets
 
 
+def _get_dataset_list_new(grp, prefix=""):
+    all_dsets = []
+    if prefix:
+        all_dsets = _get_dataset_list_new(grp[prefix])
+        all_dsets = ['/' + prefix + dset_name for dset_name in all_dsets]
+    else:
+        for key in grp.keys():
+            if isinstance(grp[key],h5py._hl.group.Group):
+                all_dsets.extend(_get_dataset_list_new(grp, key)) 
+            else:
+                all_dsets.append('/' + key)
+    return all_dsets
+
 class EagleSnapshotClosedException(Exception):
     pass
 


### PR DESCRIPTION
Re-wrote function used to retrieve names of group datasets. Previous version recently became extremely slow when used in COSMA (both for data stored in COSMA6 and COSMA7) to load data for the first time. This updated function is much faster and returns the data as the original implementation did. 

Example of first-read speed up:
![speed_comparison](https://user-images.githubusercontent.com/60343271/159042971-64d51f5e-d247-4e0c-8b26-8e5cc6525ad7.png)

This new function returns the same list of dataset names as before:
![same_results](https://user-images.githubusercontent.com/60343271/159043458-98072f96-61ec-45c8-8d25-9405799ef757.png)

Note that once the data has been read for the first time, subsequent reads take similar amounts of time.
